### PR TITLE
Iterating on cancellation logic

### DIFF
--- a/cncd/queue/queue.go
+++ b/cncd/queue/queue.go
@@ -123,8 +123,14 @@ type Queue interface {
 	// Error signals the task is complete with errors.
 	Error(c context.Context, id string, err error) error
 
+	// Error signals the task is complete with errors.
+	ErrorAtOnce(c context.Context, id []string, err error) error
+
 	// Evict removes a pending task from the queue.
 	Evict(c context.Context, id string) error
+
+	// Evict removes a pending task from the queue.
+	EvictAtOnce(c context.Context, id []string) error
 
 	// Wait waits until the task is complete.
 	Wait(c context.Context, id string) error

--- a/model/queue.go
+++ b/model/queue.go
@@ -119,3 +119,14 @@ func (q *persistentQueue) Evict(c context.Context, id string) error {
 	}
 	return err
 }
+
+// Evict removes a pending task from the queue.
+func (q *persistentQueue) EvictAtOnce(c context.Context, ids []string) error {
+	err := q.Queue.EvictAtOnce(c, ids)
+	if err == nil {
+		for _, id := range ids {
+			q.store.TaskDelete(id)
+		}
+	}
+	return err
+}

--- a/router/router.go
+++ b/router/router.go
@@ -113,7 +113,7 @@ func Load(mux *httptreemux.ContextMux, middleware ...gin.HandlerFunc) http.Handl
 		repo.POST("/move", session.MustRepoAdmin(), server.MoveRepo)
 
 		repo.POST("/builds/:number", session.MustPush, server.PostBuild)
-		repo.DELETE("/builds/:number", session.MustRepoAdmin(), server.ZombieKill)
+		repo.DELETE("/builds/:number", session.MustPush, server.DeleteBuild)
 		repo.POST("/builds/:number/approve", session.MustPush, server.PostApproval)
 		repo.POST("/builds/:number/decline", session.MustPush, server.PostDecline)
 		repo.DELETE("/builds/:number/:job", session.MustPush, server.DeleteBuild)

--- a/server/hook.go
+++ b/server/hook.go
@@ -285,7 +285,7 @@ func PostHook(c *gin.Context) {
 		}
 	}()
 
-	publishToTopic(c, build, repo)
+	publishToTopic(c, build, repo, model.Enqueued)
 	queueBuild(build, repo, buildItems)
 }
 
@@ -360,7 +360,7 @@ func findOrPersistPipelineConfig(build *model.Build, remoteYamlConfig *remote.Fi
 }
 
 // publishes message to UI clients
-func publishToTopic(c *gin.Context, build *model.Build, repo *model.Repo) {
+func publishToTopic(c *gin.Context, build *model.Build, repo *model.Repo, event model.EventType) {
 	message := pubsub.Message{
 		Labels: map[string]string{
 			"repo":    repo.FullName,


### PR DESCRIPTION
This PR makes the cancellation behavior better.

It merges two functionality together, the UI "Cancel" button and the "zombiekill" administrator feature, and any running or pending jobs can be cancelled.

Pending jobs will be removed from the persistent work queue, cancelled in the in-memory queue (should there be any edge cases) and set the state in the DB.

Running jobs will be cancelled in the in-memory queue, and the cancelled state is set on the job header. Subtasks that are submitted to the agents will wait until the agents acknowledge the cancellation and then set the state accordingly.

On the UI, cancelled pending jobs will have almost immediate feedback, cancelled running jobs may run until the agents acknowledge the cancellation.

In the edge case when the agents never acknowledge the cancellation, the job header will indicate a cancelled state, subtasks may indicate other state but this is not more than a cosmetic problem. Previously zombiekill could be used to clean up this inconsistency, which we may reintroduce/automate in the future.