### PR TITLE
feat(build): Take advantage of setup-go env

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,8 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.12.4
+      env:
+        GOPATH: /home/runner/work/woodpecker/go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -25,9 +27,7 @@ jobs:
         echo ${GITHUB_WORKSPACE}
         echo ${GOPATH}
         echo ${GOROOT}
-      env:
-        GOPATH: /home/runner/work/woodpecker/go
-
+        
     - name: Test
       run: |
         go get -u golang.org/x/tools/cmd/cover
@@ -36,10 +36,6 @@ jobs:
         go get -u github.com/golang/protobuf/proto
         go get -u github.com/golang/protobuf/protoc-gen-go
         go test -cover $(go list ./... | grep -v /vendor/)
-      env:
-        GOPATH: /home/runner/work/woodpecker/go
-
+        
     - name: Build
       run: ./.drone.sh
-      env:
-        GOPATH: /home/runner/work/woodpecker/go


### PR DESCRIPTION
- setup-go@v1 uses GOPATH to initialize
- when set, GOPATH is injected into the environment for later steps

I found your blog entries around this and it helped me immensely.  I dug into the source for setup-go and discovered that if you set GOPATH in the setup-go step, later steps in the same build will have the GOPATH already set; or at least, they seem to.  My build was much simpler than yours, but it seems to have installed golint and other tools in the expected `/home/runner/work/<repo>/go` location.