### PR TITLE
Introduce Docker builds in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+GO_VERSION=1.12.4
 export GO111MODULE=off
-
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
+
+DOCKER_RUN?=
+_with-docker:
+	$(eval DOCKER_RUN=docker run --rm -v $(shell pwd)/../../..:/go/src/ -v $(shell pwd)/build:/build -w / golang:$(GO_VERSION))
 
 all: deps build
 
@@ -17,27 +21,21 @@ format:
 	@gofmt -w ${GOFILES_NOVENDOR}
 
 test-agent:
-	go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
+	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
 
 test-server:
-ifneq ($(shell uname), "Linux")
-	$(error Target OS is not Linux drone-server build skipped)
-endif
-	go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
+	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
 
 test-lib:
-	go test -timeout 30s $(shell go list ./... | grep -v '/cmd/')
+	$(DOCKER_RUN) go test -timeout 30s $(shell go list ./... | grep -v '/cmd/')
 
 test: test-lib test-agent test-server
 
 build-agent:
-	go build -o build/drone-agent github.com/laszlocph/woodpecker/cmd/drone-agent
+	$(DOCKER_RUN) go build -o build/drone-agent github.com/laszlocph/woodpecker/cmd/drone-agent
 
 build-server:
-ifneq ($(shell uname), "Linux")
-	$(error Target OS is not Linux drone-server build skipped)
-endif
-	go build -o build/drone-server github.com/laszlocph/woodpecker/cmd/drone-server
+	$(DOCKER_RUN) go build -o build/drone-server github.com/laszlocph/woodpecker/cmd/drone-server
 
 build: build-agent build-server
 


### PR DESCRIPTION
I created a new hidden target in makefile to able to build and test the project inside a container. To build or test with Docker you have to execute `_with-docker` target before the regular target like: `make _with-docker test build`