### PR TITLE
Solve race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+GO_VERSION=1.12.4
 export GO111MODULE=off
-
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
+
+DOCKER_RUN?=
+_with-docker:
+	$(eval DOCKER_RUN=docker run --rm -v $(shell pwd)/../../..:/go/src/ -v $(shell pwd)/build:/build -w / golang:$(GO_VERSION))
 
 all: deps build
 
@@ -17,27 +21,21 @@ format:
 	@gofmt -w ${GOFILES_NOVENDOR}
 
 test-agent:
-	go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
+	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
 
 test-server:
-ifneq ($(shell uname), "Linux")
-	$(error Target OS is not Linux drone-server build skipped)
-endif
-	go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
+	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
 
 test-lib:
-	go test -timeout 30s $(shell go list ./... | grep -v '/cmd/')
+	$(DOCKER_RUN) go test -timeout 30s $(shell go list ./... | grep -v '/cmd/')
 
 test: test-lib test-agent test-server
 
 build-agent:
-	go build -o build/drone-agent github.com/laszlocph/woodpecker/cmd/drone-agent
+	$(DOCKER_RUN) go build -o build/drone-agent github.com/laszlocph/woodpecker/cmd/drone-agent
 
 build-server:
-ifneq ($(shell uname), "Linux")
-	$(error Target OS is not Linux drone-server build skipped)
-endif
-	go build -o build/drone-server github.com/laszlocph/woodpecker/cmd/drone-server
+	$(DOCKER_RUN) go build -o build/drone-server github.com/laszlocph/woodpecker/cmd/drone-server
 
 build: build-agent build-server
 

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ format:
 	@gofmt -w ${GOFILES_NOVENDOR}
 
 test-agent:
-	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
+	$(DOCKER_RUN) go test -race -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-agent $(go list ./... | grep -v /vendor/)
 
 test-server:
-	$(DOCKER_RUN) go test -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
+	$(DOCKER_RUN) go test -race -timeout 30s github.com/laszlocph/woodpecker/cmd/drone-server
 
 test-lib:
-	$(DOCKER_RUN) go test -timeout 30s $(shell go list ./... | grep -v '/cmd/')
+	$(DOCKER_RUN) go test -race -timeout 30s $(shell go list ./... | grep -v '/cmd/')
 
 test: test-lib test-agent test-server
 

--- a/cncd/queue/fifo.go
+++ b/cncd/queue/fifo.go
@@ -223,6 +223,9 @@ func (q *fifo) Resume() {
 // helper function that loops through the queue and attempts to
 // match the item to a single subscriber.
 func (q *fifo) process() {
+	q.Lock()
+	defer q.Unlock()
+
 	if q.paused {
 		return
 	}
@@ -237,9 +240,6 @@ func (q *fifo) process() {
 			log.Printf("queue: unexpected panic: %v\n%s", err, buf)
 		}
 	}()
-
-	q.Lock()
-	defer q.Unlock()
 
 	q.resubmitExpiredBuilds()
 	q.filterWaiting()


### PR DESCRIPTION
I found a race condition, namely `q.paused` is accessed with lock everywhere except `process()`.

Solves: https://github.com/laszlocph/woodpecker/issues/68
Based on: https://github.com/laszlocph/woodpecker/pull/75