### PR TITLE
Allow the agent to connect to a secure grpc endpoint

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	grpccredentials "google.golang.org/grpc/credentials"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -83,9 +85,15 @@ func loop(c *cli.Context) error {
 
 	// grpc.Dial(target, ))
 
+	var transport = grpc.WithInsecure()
+
+	if c.Bool("secure-grpc") {
+		transport = grpc.WithTransportCredentials(grpccredentials.NewTLS(&tls.Config{InsecureSkipVerify: c.Bool("skip-insecure-grpc")}))
+	}
+
 	conn, err := grpc.Dial(
 		c.String("server"),
-		grpc.WithInsecure(),
+		transport,
 		grpc.WithPerRPCCredentials(&credentials{
 			username: c.String("username"),
 			password: c.String("password"),

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -109,6 +109,16 @@ func main() {
 			Usage:  "after pinging for a keepalive check, the agent waits for a duration of this time before closing the connection if no activity",
 			Value:  time.Second * 20,
 		},
+		cli.BoolFlag{
+			Name:   "secure-grpc",
+			Usage:  "should the connection to DRONE_SERVER be made using a secure transport",
+			EnvVar: "DRONE_GRPC_SECURE",
+		},
+		cli.BoolTFlag{
+			Name:   "skip-insecure-grpc",
+			Usage:  "should the grpc server certificate be verified, only valid when DRONE_GRPC_SECURE is true",
+			EnvVar: "DRONE_GRPC_VERIFY",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Add flags to allow the agent to connect to a secure grpc endpoint.

This can be done by placing nginx in front of the drone-server or updating the
code to accept tls servers for the grpc server.

