### PR TITLE
Incomplete Gitea repository list fixed

### DIFF
--- a/remote/gitea/gitea.go
+++ b/remote/gitea/gitea.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// This file has been modified by Informatyka Boguslawski sp. z o.o.
+// This file has been modified by Informatyka Boguslawski sp. z o.o. sp.k.
 
 package gitea
 


### PR DESCRIPTION
Woodpecker may display incomplete list of Gitea repositores user has access to because Gitea forces paginated repo list reading. 

How to reproduce: create 35 test repos in Gitea and sync it to Woodpecker - only about 30 will be displayed.

This mod fixes it.

Related: https://gitea.com/gitea/go-sdk/issues/507
Author-Change-Id: IB#1107754